### PR TITLE
fix: 'description' should be single line

### DIFF
--- a/page.json
+++ b/page.json
@@ -1,7 +1,6 @@
 {
   "name": "Atakan Emre",
-  "description": "Ex. Architect | 
-  Computer Engineer Student | iOS Developer",
+  "description": "Ex. Architect | Computer Engineer Student | iOS Developer",
   "image_url": "https://pbs.twimg.com/profile_images/1633166259687661570/PTjT8-CN_400x400.jpg",
   "links": [
     {


### PR DESCRIPTION
Hi @Atakan-Emre I saw your pr on links.dev and there is a minor mistake in your page.json file. 
"description"'s value should be single line. I updated it for you.